### PR TITLE
Remove local NVD cache configuration

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -61,7 +61,3 @@ tasks {
     compilerOptions.jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_24
   }
 }
-
-dependencyCheck {
-  nvd.datafeedUrl = "file:///opt/vulnz/cache"
-}


### PR DESCRIPTION
Configuration change required to support the move to Github Pages for the NVD Cache. As per [this conversation](https://mojdt.slack.com/archives/C06MWP0UKDE/p1784300758956369) - the local configuration overrides the OWASP workflow parameter